### PR TITLE
Introduce syntax error by removing default export from RootLayout in layout.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   generator: 'v0.dev',
 }
 
-export default function RootLayout({
+default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

This pull request alters the export statement of the RootLayout component in app/layout.tsx, replacing the correct `export default function RootLayout` with the invalid `default function RootLayout`. The modification intentionally introduces a JavaScript/TypeScript syntax error, resulting in an invalid export and breaking Next.js's required default export mechanism for layout files.

*This summary was automatically generated by @propel-code-bot*