### PR TITLE
Remove unintended text after imports in protected-section.tsx

### DIFF
--- a/components/protected-section.tsx
+++ b/components/protected-section.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CheckCircle2, XCircle, ShieldCheck, LogOut } from "lucide-react"
 
-
+kjkljkl
 export default function ProtectedSection() {
   const [testResult, setTestResult] = useState<{
     success: boolean

--- a/components/protected-section.tsx
+++ b/components/protected-section.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CheckCircle2, XCircle, ShieldCheck, LogOut } from "lucide-react"
 
+
 export default function ProtectedSection() {
   const [testResult, setTestResult] = useState<{
     success: boolean


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

This pull request was intended to add a blank line after the import statements in components/protected-section.tsx to improve code formatting. However, it also inadvertently includes the insertion of the text 'kjkljkl' after the imports, which is not valid code and appears to be accidental.

*This summary was automatically generated by @propel-code-bot*