### PR TITLE
Introduce stray characters into login action import and body

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,7 +1,7 @@
 "use server"
 test_chroma_sync
 import { cookies } from "next/headers"
-import { redirect } from "next/navigation"
+import { redirect } from "next/navigation"mklmmklmlk
 import { createToken, verifyToken } from "@/lib/auth"
 
 export async function login(username: string, password: string) {
@@ -17,7 +17,7 @@ export async function login(username: string, password: string) {
       maxAge: 60 * 60, // 1 hour
       path: "/",
     })
-
+lk,l;
     // Redirect to the home pagesss
     redirect("/")
 


### PR DESCRIPTION
Fixed import statement and cleaned up code.

<!-- Summary by @propel-code-bot -->

---

**Login action import now invalid due to stray characters**

This PR touches `app/actions.ts` but introduces syntax errors instead of cleaning up the `login` action as intended. The `redirect` import line now contains extra characters and the `login` function includes a stray statement, so the module cannot compile.

<details>
<summary><strong>Key Changes</strong></summary>

• Appended `mklmmklmlk` to the `redirect` import in `app/actions.ts`, corrupting the TypeScript statement
• Inserted a stray `lk,l;` line inside the `login` function after `cookies().set`, breaking compilation

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `app/actions.ts`

</details>

---
*This summary was automatically generated by @propel-code-bot*