### PR TITLE
Add logout_v2 action to clear auth cookie and redirect home

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -35,6 +35,16 @@ export async function logout() {
   redirect("/")
 }
 
+
+export async function logout_v2() {
+  // Delete the auth cookies.
+  cookies().delete("auth-token")
+
+  // Redirect to the home page
+  redirect("/")
+}
+
+
 export async function testAuthorization() {
   // Get the token from cookies
   const token = cookies().get("auth-token")?.value

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -37,7 +37,7 @@ export async function logout() {
 
 
 export async function logout_v2() {
-  // Delete the auth cookies.
+  // Delete the auth cookies
   cookies().delete("auth-token")
 
   // Redirect to the home page


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Add duplicate `logout_v2` server action mirroring existing `logout` behavior**

This PR introduces a new server action `logout_v2` in `app/actions.ts`. The new function duplicates the existing `logout` implementation by deleting the `auth-token` cookie and redirecting to the home page.

<details>
<summary><strong>Key Changes</strong></summary>

• Added new server action `logout_v2` to `app/actions.ts`
• Implemented `logout_v2` to call `cookies().delete("auth-token")` and then `redirect("/")`, identical to the existing `logout` behavior

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• app/actions.ts
• Authentication/logout server actions

</details>

---
*This summary was automatically generated by @propel-code-bot*