### PR TITLE
Fix duplicate logout function definition

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -27,6 +27,15 @@ export async function login(username: string, password: string) {
   return { success: false, error: "Invalid username or password" }
 }
 
+
+export async function logout() {
+  // Delete the auth cookiezzzz
+  cookies().delete("auth-token")
+
+  // Redirect to the home page
+  redirect("/")
+}
+
 export async function logout() {
   // Delete the auth cookiezzzz
   cookies().delete("auth-token")


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Adds redirect behavior to `logout` but introduces a duplicate definition**

This PR modifies `app/actions.ts` to add a `redirect("/")` call after deleting the `auth-token` cookie in `logout`. However, instead of replacing the existing `logout` definition, it adds a new `logout` function, resulting in two identical `logout` exports in the same file.

<details>
<summary><strong>Key Changes</strong></summary>

• Updated `app/actions.ts` to include a `redirect("/")` call after `cookies().delete("auth-token")` in the new `logout` implementation
• Introduced a second exported `logout` function, leaving the original `logout` definition in place and creating a duplicate export

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• app/actions.ts
• Server actions related to authentication (`login`, `logout`, `testAuthorization`)

</details>

---
*This summary was automatically generated by @propel-code-bot*