### PR TITLE
Refactor: Centralize auth session helpers

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -5,8 +5,8 @@ import {
   AUTH_COOKIE_NAME,
   createToken,
   getAuthCookieOptions,
-  getSessionFromCookieStore,
 } from "@/lib/auth"
+import { buildAuthorizationResult } from "@/services/auth-session"
 
 export async function login(username: string, password: string) {
   // Simple authentication - in a real app, you would check against a databasez
@@ -35,21 +35,5 @@ export async function logout() {
 }
 
 export async function testAuthorization() {
-  const session = await getSessionFromCookieStore(cookies())
-  if (!session) {
-    return {
-      success: false,
-      message: "Unauthorized: No token provided",
-    }
-  }
-
-  return {
-    success: true,
-    message: `Authorization successful! User: ${session.username}`,
-    user: {
-      username: session.username,
-      issuedAt: session.iat ?? null,
-      expiresAt: session.exp ?? null,
-    },
-  }
+  return buildAuthorizationResult(cookies())
 }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,8 +1,12 @@
 "use server"
-test_chroma_sync_jai_mata_Di
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
-import { createToken, verifyToken } from "@/lib/auth"
+import {
+  AUTH_COOKIE_NAME,
+  createToken,
+  getAuthCookieOptions,
+  getSessionFromCookieStore,
+} from "@/lib/auth"
 
 export async function login(username: string, password: string) {
   // Simple authentication - in a real app, you would check against a databasez
@@ -11,12 +15,7 @@ export async function login(username: string, password: string) {
     const token = await createToken({ username })
 
     // Set the token in a cookie
-    cookies().set("auth-token", token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      maxAge: 60 * 60, // 1 hour
-      path: "/",
-    })
+    cookies().set(AUTH_COOKIE_NAME, token, getAuthCookieOptions())
 
     // Redirect to the home pagesss
     redirect("/")
@@ -29,39 +28,28 @@ export async function login(username: string, password: string) {
 
 export async function logout() {
   // Delete the auth cookiezzzz
-  cookies().delete("auth-token")
+  cookies().delete(AUTH_COOKIE_NAME)
 
   // Redirect to the home page
   redirect("/")
 }
 
 export async function testAuthorization() {
-  // Get the token from cookies
-  const token = cookies().get("auth-token")?.value
-
-  // If there's no token, return unauthorized
-  if (!token) {
+  const session = await getSessionFromCookieStore(cookies())
+  if (!session) {
     return {
       success: false,
       message: "Unauthorized: No token provided",
     }
   }
 
-  // Verify the token
-  try {
-    const payload = await verifyToken(token)
-
-    // If the token is valid, return success
-    return {
-      success: true,
-      message: `Authorization successful! User: ${payload.username}`,
-      user: payload,
-    }
-  } catch (error) {
-    // If the token is invalid, return unauthorized
-    return {
-      success: false,
-      message: "Unauthorized: Invalid token",
-    }
+  return {
+    success: true,
+    message: `Authorization successful! User: ${session.username}`,
+    user: {
+      username: session.username,
+      issuedAt: session.iat ?? null,
+      expiresAt: session.exp ?? null,
+    },
   }
 }

--- a/app/api/protected/route.ts
+++ b/app/api/protected/route.ts
@@ -1,32 +1,21 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { verifyToken } from "@/lib/auth"
+import { getSessionFromAuthorizationHeader } from "@/lib/auth"
 
 export async function GET(request: NextRequest) {
-  // Get the token from the Authorization header
-  const authHeader = request.headers.get("Authorization")
-  const token = authHeader?.split(" ")[1] // Bearer token
-
-  // If there's no token, return unauthorized
-  if (!token) {
-    return NextResponse.json({ error: "Unauthorized: No token provided" }, { status: 401 })
+  const session = await getSessionFromAuthorizationHeader(
+    request.headers.get("Authorization")
+  )
+  if (!session) {
+    return NextResponse.json(
+      { error: "Unauthorized: No token provided or token is invalid" },
+      { status: 401 }
+    )
   }
 
-  // Verify the token
-  try {
-    const payload = await verifyToken(token)
-
-    // If the token is invalid, return unauthorized
-    if (!payload) {
-      return NextResponse.json({ error: "Unauthorized: Invalid token" }, { status: 401 })
-    }
-
-    // If the token is valid, return the protected data
-    return NextResponse.json({
-      message: "You have access to protected data!",
-      user: payload,
-      timestamp: new Date().toISOString(),
-    })
-  } catch (error) {
-    return NextResponse.json({ error: "Unauthorized: Invalid token" }, { status: 401 })
-  }
+  return NextResponse.json({
+    message: "You have access to protected data!",
+    user: session,
+    authSource: "authorization_header",
+    timestamp: new Date().toISOString(),
+  })
 }

--- a/app/api/protected/route.ts
+++ b/app/api/protected/route.ts
@@ -1,21 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { getSessionFromAuthorizationHeader } from "@/lib/auth"
+import { buildProtectedApiResponse } from "@/services/auth-session"
 
 export async function GET(request: NextRequest) {
-  const session = await getSessionFromAuthorizationHeader(
+  const response = await buildProtectedApiResponse(
     request.headers.get("Authorization")
   )
-  if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized: No token provided or token is invalid" },
-      { status: 401 }
-    )
-  }
-
-  return NextResponse.json({
-    message: "You have access to protected data!",
-    user: session,
-    authSource: "authorization_header",
-    timestamp: new Date().toISOString(),
-  })
+  return NextResponse.json(response.body, { status: response.status })
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,16 @@
 import { cookies } from "next/headers"
 import PublicSection from "@/components/public-section"
 import ProtectedSection from "@/components/protected-section"
-import { verifyToken } from "@/lib/auth"
+import { getSessionFromCookieStore } from "@/lib/auth"
 
 export default async function Home() {
-  const cookieStore = cookies()
-  const token = cookieStore.get("auth-token")?.value
-  const isAuthenticated = token ? await verifyToken(token) : false
+  const session = await getSessionFromCookieStore(cookies())
 
   return (
     <main className="min-h-screen p-6 md:p-12 max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold mb-8">Authentication Test App</h1>
 
-      {!isAuthenticated ? <PublicSection /> : <ProtectedSection />}
+      {!session ? <PublicSection /> : <ProtectedSection session={session} />}
     </main>
   )
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,10 @@
 import { cookies } from "next/headers"
 import PublicSection from "@/components/public-section"
 import ProtectedSection from "@/components/protected-section"
-import { getSessionFromCookieStore } from "@/lib/auth"
+import { resolveSessionFromCookies } from "@/services/auth-session"
 
 export default async function Home() {
-  const session = await getSessionFromCookieStore(cookies())
+  const session = await resolveSessionFromCookies(cookies())
 
   return (
     <main className="min-h-screen p-6 md:p-12 max-w-4xl mx-auto">

--- a/components/protected-section.tsx
+++ b/components/protected-section.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CheckCircle2, XCircle, ShieldCheck, LogOut } from "lucide-react"
 import type { AuthSession } from "@/lib/auth"
+import { buildSessionSnapshot, formatSessionExpiry } from "@/services/auth-session"
 
 interface ProtectedSectionProps {
   session: AuthSession
@@ -26,9 +27,8 @@ export default function ProtectedSection({ session }: ProtectedSectionProps) {
     }
   } | null>(null)
   const [loading, setLoading] = useState(false)
-  const sessionExpiresAt = session.exp
-    ? new Date(session.exp * 1000).toLocaleString()
-    : "Unknown"
+  const sessionSnapshot = buildSessionSnapshot(session)
+  const sessionExpiresAt = formatSessionExpiry(sessionSnapshot.expiresAt)
 
   const handleTestAuth = async () => {
     setLoading(true)
@@ -114,7 +114,7 @@ export default function ProtectedSection({ session }: ProtectedSectionProps) {
                       Token Location: <span className="font-semibold">HTTP Cookie (auth-token)</span>
                     </div>
                     <div>
-                      Session User: <span className="font-semibold">{session.username}</span>
+                      Session User: <span className="font-semibold">{sessionSnapshot.username}</span>
                     </div>
                     <div>
                       Expires At: <span className="font-semibold">{sessionExpiresAt}</span>

--- a/components/protected-section.tsx
+++ b/components/protected-section.tsx
@@ -8,14 +8,27 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CheckCircle2, XCircle, ShieldCheck, LogOut } from "lucide-react"
+import type { AuthSession } from "@/lib/auth"
 
-export default function ProtectedSection() {
+interface ProtectedSectionProps {
+  session: AuthSession
+}
+
+export default function ProtectedSection({ session }: ProtectedSectionProps) {
   const [testResult, setTestResult] = useState<{
     success: boolean
     message: string
     timestamp?: string
+    user?: {
+      username: string
+      issuedAt: number | null
+      expiresAt: number | null
+    }
   } | null>(null)
   const [loading, setLoading] = useState(false)
+  const sessionExpiresAt = session.exp
+    ? new Date(session.exp * 1000).toLocaleString()
+    : "Unknown"
 
   const handleTestAuth = async () => {
     setLoading(true)
@@ -25,8 +38,9 @@ export default function ProtectedSection() {
         success: result.success,
         message: result.message,
         timestamp: new Date().toLocaleTimeString(),
+        user: result.success ? result.user : undefined,
       })
-    } catch (error) {
+    } catch {
       setTestResult({
         success: false,
         message: "Failed to test authorization",
@@ -44,7 +58,10 @@ export default function ProtectedSection() {
           <div className="flex justify-between items-center">
             <div>
               <CardTitle>Protected Section</CardTitle>
-              <CardDescription>This section is only visible to authenticated users</CardDescription>
+              <CardDescription>
+                This section is only visible to authenticated users.
+                Signed in as <span className="font-medium">{session.username}</span>.
+              </CardDescription>
             </div>
             <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
               <CheckCircle2 className="h-3.5 w-3.5 mr-1" />
@@ -75,6 +92,11 @@ export default function ProtectedSection() {
                   {testResult.success ? <CheckCircle2 className="h-4 w-4" /> : <XCircle className="h-4 w-4" />}
                   <AlertDescription className="flex flex-col">
                     <span>{testResult.message}</span>
+                    {testResult.user && (
+                      <span className="text-xs text-muted-foreground mt-1">
+                        Verified session for {testResult.user.username}
+                      </span>
+                    )}
                     <span className="text-xs text-muted-foreground mt-1">{testResult.timestamp}</span>
                   </AlertDescription>
                 </Alert>
@@ -92,7 +114,10 @@ export default function ProtectedSection() {
                       Token Location: <span className="font-semibold">HTTP Cookie (auth-token)</span>
                     </div>
                     <div>
-                      Expiration: <span className="font-semibold">1 hour</span>
+                      Session User: <span className="font-semibold">{session.username}</span>
+                    </div>
+                    <div>
+                      Expires At: <span className="font-semibold">{sessionExpiresAt}</span>
                     </div>
                     <div>
                       Signed with: <span className="font-semibold">HS256</span>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,7 +5,7 @@ const JWT_SECRET = new TextEncoder().encode("your-secret-key-at-least-32-chars-l
 
 export const AUTH_COOKIE_NAME = "auth-token"
 
-type CookieStoreLike = {
+export type CookieStoreLike = {
   get(name: string): { value: string } | undefined
 }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,28 @@
-import { SignJWT, jwtVerify } from "jose"
+import { type JWTPayload, SignJWT, jwtVerify } from "jose"
 
 // In a real app, you would use a proper secret from environment variables
 const JWT_SECRET = new TextEncoder().encode("your-secret-key-at-least-32-chars-long")
 
-export async function createToken(payload: any) {
+export const AUTH_COOKIE_NAME = "auth-token"
+
+type CookieStoreLike = {
+  get(name: string): { value: string } | undefined
+}
+
+export interface AuthSession extends JWTPayload {
+  username: string
+}
+
+export function getAuthCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60,
+    path: "/",
+  }
+}
+
+export async function createToken(payload: Pick<AuthSession, "username">) {
   const token = await new SignJWT(payload)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
@@ -16,8 +35,48 @@ export async function createToken(payload: any) {
 export async function verifyToken(token: string) {
   try {
     const { payload } = await jwtVerify(token, JWT_SECRET)
-    return payload
-  } catch (error) {
-    return false
+    if (typeof payload.username !== "string") {
+      return null
+    }
+    return payload as AuthSession
+  } catch {
+    return null
   }
+}
+
+export function getTokenFromCookieStore(cookieStore: CookieStoreLike) {
+  return cookieStore.get(AUTH_COOKIE_NAME)?.value ?? null
+}
+
+export function getTokenFromAuthorizationHeader(authHeader: string | null) {
+  if (!authHeader) {
+    return null
+  }
+
+  const [scheme, token] = authHeader.split(" ")
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return null
+  }
+
+  return token
+}
+
+export async function getSessionFromCookieStore(cookieStore: CookieStoreLike) {
+  const token = getTokenFromCookieStore(cookieStore)
+  if (!token) {
+    return null
+  }
+
+  return verifyToken(token)
+}
+
+export async function getSessionFromAuthorizationHeader(
+  authHeader: string | null
+) {
+  const token = getTokenFromAuthorizationHeader(authHeader)
+  if (!token) {
+    return null
+  }
+
+  return verifyToken(token)
 }

--- a/services/auth-session.ts
+++ b/services/auth-session.ts
@@ -1,0 +1,82 @@
+import {
+  getSessionFromAuthorizationHeader,
+  getSessionFromCookieStore,
+  type AuthSession,
+  type CookieStoreLike,
+} from "@/lib/auth"
+
+export interface SessionSnapshot {
+  username: string
+  issuedAt: number | null
+  expiresAt: number | null
+}
+
+export function buildSessionSnapshot(
+  session: AuthSession
+): SessionSnapshot {
+  return {
+    username: session.username,
+    issuedAt: session.iat ?? null,
+    expiresAt: session.exp ?? null,
+  }
+}
+
+export function formatSessionExpiry(expiresAt: number | null) {
+  if (!expiresAt) {
+    return "Unknown"
+  }
+
+  return new Date(expiresAt * 1000).toLocaleString()
+}
+
+export async function resolveSessionFromCookies(
+  cookieStore: CookieStoreLike
+) {
+  return getSessionFromCookieStore(cookieStore)
+}
+
+export async function resolveSessionFromAuthorizationHeader(
+  authHeader: string | null
+) {
+  return getSessionFromAuthorizationHeader(authHeader)
+}
+
+export async function buildAuthorizationResult(
+  cookieStore: CookieStoreLike
+) {
+  const session = await resolveSessionFromCookies(cookieStore)
+  if (!session) {
+    return {
+      success: false,
+      message: "Unauthorized: No token provided",
+    }
+  }
+
+  return {
+    success: true,
+    message: `Authorization successful! User: ${session.username}`,
+    user: buildSessionSnapshot(session),
+  }
+}
+
+export async function buildProtectedApiResponse(authHeader: string | null) {
+  const session = await resolveSessionFromAuthorizationHeader(authHeader)
+  if (!session) {
+    return {
+      status: 401,
+      body: {
+        error: "Unauthorized: No token provided or token is invalid",
+      },
+    }
+  }
+
+  return {
+    status: 200,
+    body: {
+      message: "You have access to protected data!",
+      user: buildSessionSnapshot(session),
+      authSource: "authorization_header",
+      timestamp: new Date().toISOString(),
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- keep JWT creation, verification, and cookie primitives in lib/auth.ts
- route cookie and authorization-header session resolution through services/auth-session.ts
- reuse the shared auth-session service in app/actions.ts, app/api/protected/route.ts, app/page.tsx, and components/protected-section.tsx
- surface authenticated session snapshots in the protected UI and protected API response

## Architecture
- UI entry points and route handlers now depend on services/auth-session.ts
- services/auth-session.ts depends on lib/auth.ts for low-level token parsing and JWT helpers
- the intended flow is: page, actions, route, and protected UI -> auth session service -> auth token utilities

## Why
This PR is meant to be a strong happy-path candidate for the PR summary Change Map feature because it creates one explicit shared service node with multiple production callers.

## Testing
- pnpm build
- pnpm lint (not runnable without first initializing a Next.js ESLint config in this repo)

<!-- Summary by @propel-code-bot -->

---

This refactor also aims to reduce duplication and simplify session handling, resulting in cleaner, more maintainable code.

---
*This summary was automatically generated by @propel-code-bot*