### PR TITLE
Add auth session diagnostics flow

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,12 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { buildAuthSessionApiResponse } from "@/services/auth-session-service"
+
+export async function GET(request: NextRequest) {
+  const authSessionApiResponse = await buildAuthSessionApiResponse(
+    request.headers.get("Authorization")
+  )
+
+  return NextResponse.json(authSessionApiResponse.body, {
+    status: authSessionApiResponse.status,
+  })
+}

--- a/app/auth/session/actions.ts
+++ b/app/auth/session/actions.ts
@@ -1,0 +1,8 @@
+"use server"
+
+import { cookies } from "next/headers"
+import { checkAuthSessionFromCookies } from "@/services/auth-session-service"
+
+export async function checkAuthSessionAction() {
+  return checkAuthSessionFromCookies(cookies())
+}

--- a/app/auth/session/page.tsx
+++ b/app/auth/session/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link"
+import { cookies } from "next/headers"
+import AuthSessionPanel from "@/components/auth-session-panel"
+import { resolveAuthSessionSnapshotFromCookies } from "@/services/auth-session-service"
+
+export default async function AuthSessionPage() {
+  const authSessionSnapshot = await resolveAuthSessionSnapshotFromCookies(
+    cookies()
+  )
+
+  return (
+    <main className="min-h-screen max-w-4xl mx-auto p-6 md:p-12">
+      <div className="mb-8 space-y-3">
+        <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
+          Auth Session Diagnostics
+        </p>
+        <h1 className="text-3xl font-bold">Inspect the Auth Session Flow</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          This auth session page is a focused view over the auth session action,
+          auth session API route, auth session service, and auth session store.
+        </p>
+        <Link href="/" className="text-sm font-medium underline underline-offset-4">
+          Return to the authentication test app
+        </Link>
+      </div>
+
+      <AuthSessionPanel authSessionSnapshot={authSessionSnapshot} />
+    </main>
+  )
+}

--- a/components/auth-session-panel.tsx
+++ b/components/auth-session-panel.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useState } from "react"
+import { checkAuthSessionAction } from "@/app/auth/session/actions"
+import type { AuthSessionSnapshot } from "@/services/auth-session-service"
+import { formatAuthSessionExpiry } from "@/services/auth-session-service"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { CheckCircle2, ShieldCheck, XCircle } from "lucide-react"
+
+interface AuthSessionPanelProps {
+  authSessionSnapshot: AuthSessionSnapshot | null
+}
+
+export default function AuthSessionPanel({
+  authSessionSnapshot,
+}: AuthSessionPanelProps) {
+  const [authSessionCheck, setAuthSessionCheck] = useState<{
+    success: boolean
+    message: string
+    authSessionSnapshot?: AuthSessionSnapshot
+    checkedAt: string
+  } | null>(null)
+  const [isCheckingAuthSession, setIsCheckingAuthSession] = useState(false)
+
+  const handleCheckAuthSession = async () => {
+    setIsCheckingAuthSession(true)
+
+    try {
+      const result = await checkAuthSessionAction()
+      setAuthSessionCheck({
+        ...result,
+        checkedAt: new Date().toLocaleTimeString(),
+      })
+    } catch {
+      setAuthSessionCheck({
+        success: false,
+        message: "Failed to run the auth session check.",
+        checkedAt: new Date().toLocaleTimeString(),
+      })
+    } finally {
+      setIsCheckingAuthSession(false)
+    }
+  }
+
+  const displayedAuthSession = authSessionCheck?.authSessionSnapshot ?? authSessionSnapshot
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle>Auth Session Panel</CardTitle>
+            <CardDescription>
+              This page exercises the auth session page, auth session action, auth
+              session API route, auth session service, and auth session store.
+            </CardDescription>
+          </div>
+          <Badge
+            variant="outline"
+            className={
+              displayedAuthSession
+                ? "bg-green-50 text-green-700 border-green-200"
+                : "bg-amber-50 text-amber-700 border-amber-200"
+            }
+          >
+            {displayedAuthSession ? "Auth Session Active" : "No Auth Session"}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-md border bg-muted/40 p-4 text-sm">
+          <div>
+            Auth Session Route:{" "}
+            <span className="font-mono font-semibold">/api/auth/session</span>
+          </div>
+          <div>
+            Auth Session Service:{" "}
+            <span className="font-mono font-semibold">
+              services/auth-session-service.ts
+            </span>
+          </div>
+          <div>
+            Auth Session Store:{" "}
+            <span className="font-mono font-semibold">
+              lib/auth-session-store.ts
+            </span>
+          </div>
+        </div>
+
+        <Button
+          onClick={handleCheckAuthSession}
+          disabled={isCheckingAuthSession}
+          className="gap-2"
+        >
+          <ShieldCheck className="h-4 w-4" />
+          {isCheckingAuthSession ? "Checking Auth Session..." : "Check Auth Session"}
+        </Button>
+
+        {authSessionCheck && (
+          <Alert
+            variant={authSessionCheck.success ? "default" : "destructive"}
+          >
+            {authSessionCheck.success ? (
+              <CheckCircle2 className="h-4 w-4" />
+            ) : (
+              <XCircle className="h-4 w-4" />
+            )}
+            <AlertDescription className="flex flex-col">
+              <span>{authSessionCheck.message}</span>
+              <span className="mt-1 text-xs text-muted-foreground">
+                Checked at {authSessionCheck.checkedAt}
+              </span>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="rounded-md border bg-background p-4 text-sm">
+          <h3 className="mb-3 font-medium">Current Auth Session Snapshot</h3>
+          {displayedAuthSession ? (
+            <div className="space-y-2 font-mono text-xs">
+              <div>
+                Username:{" "}
+                <span className="font-semibold">
+                  {displayedAuthSession.username}
+                </span>
+              </div>
+              <div>
+                Source:{" "}
+                <span className="font-semibold">
+                  {displayedAuthSession.source}
+                </span>
+              </div>
+              <div>
+                Expires At:{" "}
+                <span className="font-semibold">
+                  {formatAuthSessionExpiry(displayedAuthSession.expiresAt)}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-muted-foreground">
+              No auth session snapshot is currently available. Log in on the home
+              page first, then revisit this auth session page.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/auth-session-store.ts
+++ b/lib/auth-session-store.ts
@@ -1,0 +1,83 @@
+import { verifyToken } from "@/lib/auth"
+
+const AUTH_SESSION_COOKIE_NAME = "auth-token"
+
+export type AuthSessionSource = "cookie" | "authorization_header"
+
+export type CookieStoreLike = {
+  get(name: string): { value: string } | undefined
+}
+
+export interface AuthSessionRecord {
+  username: string
+  issuedAt: number | null
+  expiresAt: number | null
+  source: AuthSessionSource
+}
+
+function normalizeAuthSessionRecord(
+  payload: unknown,
+  source: AuthSessionSource
+): AuthSessionRecord | null {
+  if (!payload || typeof payload !== "object") {
+    return null
+  }
+
+  const sessionPayload = payload as {
+    username?: unknown
+    iat?: unknown
+    exp?: unknown
+  }
+
+  if (typeof sessionPayload.username !== "string") {
+    return null
+  }
+
+  return {
+    username: sessionPayload.username,
+    issuedAt: typeof sessionPayload.iat === "number" ? sessionPayload.iat : null,
+    expiresAt: typeof sessionPayload.exp === "number" ? sessionPayload.exp : null,
+    source,
+  }
+}
+
+export function readAuthSessionTokenFromCookies(cookieStore: CookieStoreLike) {
+  return cookieStore.get(AUTH_SESSION_COOKIE_NAME)?.value ?? null
+}
+
+export function readAuthSessionTokenFromAuthorizationHeader(
+  authorizationHeader: string | null
+) {
+  if (!authorizationHeader) {
+    return null
+  }
+
+  const [scheme, token] = authorizationHeader.split(" ")
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return null
+  }
+
+  return token
+}
+
+export async function readAuthSessionFromCookies(cookieStore: CookieStoreLike) {
+  const token = readAuthSessionTokenFromCookies(cookieStore)
+  if (!token) {
+    return null
+  }
+
+  const payload = await verifyToken(token)
+  return normalizeAuthSessionRecord(payload, "cookie")
+}
+
+export async function readAuthSessionFromAuthorizationHeader(
+  authorizationHeader: string | null
+) {
+  const token = readAuthSessionTokenFromAuthorizationHeader(authorizationHeader)
+  if (!token) {
+    return null
+  }
+
+  const payload = await verifyToken(token)
+  return normalizeAuthSessionRecord(payload, "authorization_header")
+}

--- a/services/auth-session-service.ts
+++ b/services/auth-session-service.ts
@@ -1,0 +1,88 @@
+import {
+  readAuthSessionFromAuthorizationHeader,
+  readAuthSessionFromCookies,
+  type AuthSessionRecord,
+  type CookieStoreLike,
+} from "@/lib/auth-session-store"
+
+export interface AuthSessionSnapshot {
+  username: string
+  issuedAt: number | null
+  expiresAt: number | null
+  source: string
+}
+
+export function buildAuthSessionSnapshot(
+  authSessionRecord: AuthSessionRecord
+): AuthSessionSnapshot {
+  return {
+    username: authSessionRecord.username,
+    issuedAt: authSessionRecord.issuedAt,
+    expiresAt: authSessionRecord.expiresAt,
+    source: authSessionRecord.source,
+  }
+}
+
+export function formatAuthSessionExpiry(expiresAt: number | null) {
+  if (!expiresAt) {
+    return "Unknown"
+  }
+
+  return new Date(expiresAt * 1000).toLocaleString()
+}
+
+export async function resolveAuthSessionSnapshotFromCookies(
+  cookieStore: CookieStoreLike
+) {
+  const authSessionRecord = await readAuthSessionFromCookies(cookieStore)
+  if (!authSessionRecord) {
+    return null
+  }
+
+  return buildAuthSessionSnapshot(authSessionRecord)
+}
+
+export async function checkAuthSessionFromCookies(
+  cookieStore: CookieStoreLike
+) {
+  const authSessionSnapshot = await resolveAuthSessionSnapshotFromCookies(
+    cookieStore
+  )
+  if (!authSessionSnapshot) {
+    return {
+      success: false,
+      message: "No active auth session was found in the auth-token cookie.",
+    }
+  }
+
+  return {
+    success: true,
+    message: `Resolved auth session for ${authSessionSnapshot.username}.`,
+    authSessionSnapshot,
+  }
+}
+
+export async function buildAuthSessionApiResponse(
+  authorizationHeader: string | null
+) {
+  const authSessionRecord = await readAuthSessionFromAuthorizationHeader(
+    authorizationHeader
+  )
+  if (!authSessionRecord) {
+    return {
+      status: 401,
+      body: {
+        error: "Unauthorized: No valid auth session bearer token was provided.",
+      },
+    }
+  }
+
+  return {
+    status: 200,
+    body: {
+      message: "Resolved auth session from the authorization header.",
+      authSessionSnapshot: buildAuthSessionSnapshot(authSessionRecord),
+      timestamp: new Date().toISOString(),
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add auth session diagnostics flow

## Testing
- pnpm build

<!-- Summary by @propel-code-bot -->

---

It adds a dedicated `/auth/session` page that displays current session details from cookies with a client-side re-check via a Server Action, and introduces a `GET /api/auth/session` endpoint for bearer-token session checks, structured through a service layer and low-level token store.

<details>
<summary><strong>Key Changes</strong></summary>

• Introduced a new page at `app/auth/session/page.tsx` to display session information.
• Created a new React component `components/auth-session-panel.tsx` to render session details and handle client-side checks.
• Added a Next.js Server Action in `app/auth/session/actions.ts` to allow the client to re-validate the session.
• Established a new API endpoint `GET /api/auth/session` in `app/api/auth/session/route.ts` for checking sessions via bearer tokens.
• Created `services/auth-session-service.ts` to orchestrate session validation logic and build API responses.
• Implemented `lib/auth-session-store.ts` to handle low-level token extraction from cookies/headers and payload normalization.

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• app/auth/session/
• app/api/auth/session/
• components/
• services/
• lib/

</details>

<details>
<summary><strong>Change Map</strong></summary>

```mermaid
flowchart TD
  subgraph UI_Layer
    N_app_auth_session_actions_191f["app/auth/session/actions.ts"]
    N_app_auth_session_page_14cf["app/auth/session/page.tsx"]
  end
  subgraph API_Layer
    N_app_api_auth_session_route_bd96["app/api/auth/session/route.ts"]
  end
  subgraph Application_Layer
    N_components_auth_session_panel_cc0b["components/auth-session-panel.tsx"]
    N_lib_auth_session_store_3bf9["lib/auth-session-store.ts"]
    N_services_auth_session_service_6456["services/auth-session-service.ts"]
  end
  N_app_api_auth_session_route_bd96 --> N_services_auth_session_service_6456
  N_app_auth_session_actions_191f --> N_services_auth_session_service_6456
  N_app_auth_session_page_14cf --> N_components_auth_session_panel_cc0b
  N_app_auth_session_page_14cf --> N_services_auth_session_service_6456
  N_components_auth_session_panel_cc0b --> N_app_auth_session_actions_191f
  N_components_auth_session_panel_cc0b --> N_services_auth_session_service_6456
  N_services_auth_session_service_6456 --> N_lib_auth_session_store_3bf9
```
</details>

---
*This summary was automatically generated by @propel-code-bot*